### PR TITLE
fixed cmake warning of minimum version required

### DIFF
--- a/AddInManager/CMakeLists.txt
+++ b/AddInManager/CMakeLists.txt
@@ -23,7 +23,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 set(target_name addinmanager)
 project(${target_name})

--- a/AddInManager/CMakeLists.txt
+++ b/AddInManager/CMakeLists.txt
@@ -23,7 +23,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 
 set(target_name addinmanager)
 project(${target_name})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 project(itom)
 

--- a/DataObject/CMakeLists.txt
+++ b/DataObject/CMakeLists.txt
@@ -23,7 +23,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 
 set(target_name dataobject)
 project(${target_name})

--- a/DataObject/CMakeLists.txt
+++ b/DataObject/CMakeLists.txt
@@ -23,7 +23,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 set(target_name dataobject)
 project(${target_name})

--- a/PointCloud/CMakeLists.txt
+++ b/PointCloud/CMakeLists.txt
@@ -23,7 +23,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 set(target_name pointcloud)
 project(${target_name})

--- a/PointCloud/CMakeLists.txt
+++ b/PointCloud/CMakeLists.txt
@@ -23,7 +23,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 
 set(target_name pointcloud)
 project(${target_name})

--- a/QPropertyEditor/CMakeLists.txt
+++ b/QPropertyEditor/CMakeLists.txt
@@ -23,7 +23,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 
 set(target_name qpropertyeditor)
 project(${target_name})

--- a/QPropertyEditor/CMakeLists.txt
+++ b/QPropertyEditor/CMakeLists.txt
@@ -23,7 +23,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 set(target_name qpropertyeditor)
 project(${target_name})

--- a/Qitom/CMakeLists.txt
+++ b/Qitom/CMakeLists.txt
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 set(target_name qitom)
 project(${target_name})

--- a/Qitom/CMakeLists.txt
+++ b/Qitom/CMakeLists.txt
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 
 set(target_name qitom)
 project(${target_name})

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -23,7 +23,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 
 set(target_name itomCommonLib)
 project(${target_name})

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -23,7 +23,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 set(target_name itomCommonLib)
 project(${target_name})

--- a/commonQt/CMakeLists.txt
+++ b/commonQt/CMakeLists.txt
@@ -23,7 +23,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 
 set(target_name itomCommonQtLib)
 project(${target_name})

--- a/commonQt/CMakeLists.txt
+++ b/commonQt/CMakeLists.txt
@@ -23,7 +23,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 set(target_name itomCommonQtLib)
 project(${target_name})

--- a/docs/userDoc/source/02_installation/build_dependencies.rst
+++ b/docs/userDoc/source/02_installation/build_dependencies.rst
@@ -17,10 +17,10 @@ Software packages
 
 - IDE (e.g. Visual Studio 2015 Professional, QtCreator...)
 - Compiler: The C++ compiler must support at least the **C++11** standard.
-- CMake (recommended 3.1 or higher)
-- Qt5-framework (>= 5.5 required, >= 5.6 recommended)
+- CMake (recommended 3.12 or higher)
+- Qt5-framework or Qt6-framework (>= 5.5 required, >= 5.6 recommended)
 - OpenCV 3.2 or higher (3.x recommended)
-- Python 3.5 or higher, 3.6 or higher recommended
+- Python 3.5 or higher, 3.7 or higher recommended
 - Git (git-scm.com) + GUI (e.g. TortoiseGit or GitExtensions) for accessing the remote repository
 - Python-Package: NumPy
 
@@ -61,14 +61,14 @@ It is also possible to use the free express edition of Visual Studio.
 
 Download **CMake** from http://www.cmake.org/cmake/resources/software.html and install it.
 Or just download it and use that. no need to install.
-If possible use any version higher than 3.1. CMake reads the platform-independent
+If possible use any version higher than 3.12. CMake reads the platform-independent
 project files of |itom| (CMakeList.txt) and generates the corresponding project
 files for your compiler, IDE and platform.
 
 **Qt-framework** (mandatory)
 ''''''''''''''''''''''''''''''''
 
-Download the **Qt5-framework** (>= 5.5 required, >= 5.6 recommended)
+Download the **Qt5-framework or Qt6-framework** (>= 5.5 required, >= 5.6 recommended)
 from http://qt-project.org/downloads. If you find a setup version for your IDE and compiler,
 you can directly install it. Otherwise, you need to configure and build **Qt**
 on your computer - see box below. Either download the ready-to-use binaries from
@@ -231,7 +231,7 @@ Add the path to the bin-folder of PointCloud-library to the windows environment 
 
 :ref:`build_dependencies_vtk`
 
-**Python** (mandatory, 3.5 or higher, 3.6 or higher is recommended)
+**Python** (mandatory, 3.5 or higher, 3.7 or higher is recommended)
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 Download the installer from http://www.python.org/download/ and install python in

--- a/docs/userDoc/source/07_plugins/development/pluginCreateCMake.rst
+++ b/docs/userDoc/source/07_plugins/development/pluginCreateCMake.rst
@@ -34,7 +34,7 @@ This file usually already contains a lot of subdirectories, added by the CMake-c
 
     project(itom_plugins) #name of the overall project
 
-    cmake_minimum_required(VERSION 3.1...3.15)
+    cmake_minimum_required(VERSION 3.12...3.24)
 
     option(BUILD_TARGET64 "Build for 64 bit target if set to ON or 32 bit if set to OFF." ON)
 

--- a/gtest-1.10.0/CMakeLists.txt
+++ b/gtest-1.10.0/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Note: CMake support is community-based. The maintainers do not use CMake
 # internally.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/gtest-1.10.0/CMakeLists.txt
+++ b/gtest-1.10.0/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Note: CMake support is community-based. The maintainers do not use CMake
 # internally.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/gtest-1.10.0/googletest/CMakeLists.txt
+++ b/gtest-1.10.0/googletest/CMakeLists.txt
@@ -53,7 +53,7 @@ else()
   cmake_policy(SET CMP0048 NEW)
   project(gtest VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
 endif()
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 if (POLICY CMP0063) # Visibility
   cmake_policy(SET CMP0063 NEW)

--- a/gtest-1.10.0/googletest/CMakeLists.txt
+++ b/gtest-1.10.0/googletest/CMakeLists.txt
@@ -53,7 +53,7 @@ else()
   cmake_policy(SET CMP0048 NEW)
   project(gtest VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
 endif()
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 
 if (POLICY CMP0063) # Visibility
   cmake_policy(SET CMP0063 NEW)

--- a/iconThemes/CMakeLists.txt
+++ b/iconThemes/CMakeLists.txt
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.1...3.15)
+cmake_minimum_required(VERSION 3.12)
 
 if(${CMAKE_VERSION} VERSION_LESS 3.12)
     cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})

--- a/iconThemes/CMakeLists.txt
+++ b/iconThemes/CMakeLists.txt
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 if(${CMAKE_VERSION} VERSION_LESS 3.12)
     cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})

--- a/itomWidgets/CMakeLists.txt
+++ b/itomWidgets/CMakeLists.txt
@@ -24,7 +24,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 set(target_name itomWidgets)
 project(${target_name})

--- a/itomWidgets/CMakeLists.txt
+++ b/itomWidgets/CMakeLists.txt
@@ -24,7 +24,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 
 set(target_name itomWidgets)
 project(${target_name})

--- a/itom_unittests/CMakeLists.txt
+++ b/itom_unittests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.12)
 
 add_subdirectory(unittest_dataobject)
 add_subdirectory(unittest_commonlib)

--- a/itom_unittests/CMakeLists.txt
+++ b/itom_unittests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 add_subdirectory(unittest_dataobject)
 add_subdirectory(unittest_commonlib)

--- a/itom_unittests/unittest_addinmanager/CMakeLists.txt
+++ b/itom_unittests/unittest_addinmanager/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 set(target_name unittest_addinmanager)
 

--- a/itom_unittests/unittest_addinmanager/CMakeLists.txt
+++ b/itom_unittests/unittest_addinmanager/CMakeLists.txt
@@ -1,8 +1,8 @@
+cmake_minimum_required(VERSION 3.12)
+
 set(target_name unittest_addinmanager)
 
 project(${target_name})
-
-cmake_minimum_required(VERSION 3.0.2)
 
 option(BUILD_TARGET64 "Build for 64 bit target if set to ON or 32 bit if set to OFF." ON)
 

--- a/itom_unittests/unittest_commonlib/CMakeLists.txt
+++ b/itom_unittests/unittest_commonlib/CMakeLists.txt
@@ -1,8 +1,8 @@
+cmake_minimum_required(VERSION 3.12)
+
 set(target_name unittest_commonlib)
 
 project(${target_name})
-
-cmake_minimum_required(VERSION 3.0.2)
 
 option(BUILD_TARGET64 "Build for 64 bit target if set to ON or 32 bit if set to OFF." ON)
 

--- a/itom_unittests/unittest_commonlib/CMakeLists.txt
+++ b/itom_unittests/unittest_commonlib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 set(target_name unittest_commonlib)
 

--- a/itom_unittests/unittest_commonqtlib/CMakeLists.txt
+++ b/itom_unittests/unittest_commonqtlib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 set(target_name unittest_commonqtlib)
 

--- a/itom_unittests/unittest_commonqtlib/CMakeLists.txt
+++ b/itom_unittests/unittest_commonqtlib/CMakeLists.txt
@@ -1,8 +1,8 @@
+cmake_minimum_required(VERSION 3.12)
+
 set(target_name unittest_commonqtlib)
 
 project(${target_name})
-
-cmake_minimum_required(VERSION 3.0.2)
 
 option(BUILD_TARGET64 "Build for 64 bit target if set to ON or 32 bit if set to OFF." ON)
 

--- a/itom_unittests/unittest_dataobject/CMakeLists.txt
+++ b/itom_unittests/unittest_dataobject/CMakeLists.txt
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 set(target_name unittest_dataobject)
 project(${target_name})

--- a/itom_unittests/unittest_dataobject/CMakeLists.txt
+++ b/itom_unittests/unittest_dataobject/CMakeLists.txt
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 
 set(target_name unittest_dataobject)
 project(${target_name})

--- a/itom_unittests/unittest_qpropertyeditor/CMakeLists.txt
+++ b/itom_unittests/unittest_qpropertyeditor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 set(target_name unittest_qpropertyeditor)
 

--- a/itom_unittests/unittest_qpropertyeditor/CMakeLists.txt
+++ b/itom_unittests/unittest_qpropertyeditor/CMakeLists.txt
@@ -1,8 +1,8 @@
+cmake_minimum_required(VERSION 3.12)
+
 set(target_name unittest_qpropertyeditor)
 
 project(${target_name})
-
-cmake_minimum_required(VERSION 3.0.2)
 
 option(BUILD_TARGET64 "Build for 64 bit target if set to ON or 32 bit if set to OFF." ON)
 option(BUILD_UNITTEST_INTERNAL_ENABLE "If set, some libraries are compiled to export some internal methods, too. These can be tested then in unittests." OFF)

--- a/plot/CMakeLists.txt
+++ b/plot/CMakeLists.txt
@@ -23,7 +23,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 
 set(target_name itomCommonPlotLib)
 project(${target_name})

--- a/plot/CMakeLists.txt
+++ b/plot/CMakeLists.txt
@@ -23,7 +23,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 set(target_name itomCommonPlotLib)
 project(${target_name})

--- a/pluginTemplates/actuator/CMakeLists.txt
+++ b/pluginTemplates/actuator/CMakeLists.txt
@@ -7,11 +7,11 @@
 ###################################################################
 ###################################################################
 
+# this should be the first line of your project.
+cmake_minimum_required(VERSION 3.12)
+
 #here you give your project a unique name (replace MyActuatorPlugin by the desired project name of your plugin)
 set(target_name MyActuatorPlugin)
-
-# this should be the first line of your project.
-cmake_minimum_required(VERSION 3.1...3.15)
 
 #this is to automatically detect the SDK subfolder of the itom build directory.
 if(NOT EXISTS ${ITOM_SDK_DIR})

--- a/pluginTemplates/actuator/CMakeLists.txt
+++ b/pluginTemplates/actuator/CMakeLists.txt
@@ -8,7 +8,7 @@
 ###################################################################
 
 # this should be the first line of your project.
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 #here you give your project a unique name (replace MyActuatorPlugin by the desired project name of your plugin)
 set(target_name MyActuatorPlugin)

--- a/pluginTemplates/algorithm/CMakeLists.txt
+++ b/pluginTemplates/algorithm/CMakeLists.txt
@@ -7,11 +7,11 @@
 ###################################################################
 ###################################################################
 
+# this should be the first line of your project.
+cmake_minimum_required(VERSION 3.12)
+
 #here you give your project a unique name (replace MyAlgoPlugin by the desired project name of your plugin)
 set(target_name MyAlgoPlugin)
-
-# this should be the first line of your project.
-cmake_minimum_required(VERSION 3.1...3.15)
 
 #this is to automatically detect the SDK subfolder of the itom build directory.
 if(NOT EXISTS ${ITOM_SDK_DIR})

--- a/pluginTemplates/algorithm/CMakeLists.txt
+++ b/pluginTemplates/algorithm/CMakeLists.txt
@@ -8,7 +8,7 @@
 ###################################################################
 
 # this should be the first line of your project.
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 #here you give your project a unique name (replace MyAlgoPlugin by the desired project name of your plugin)
 set(target_name MyAlgoPlugin)

--- a/pluginTemplates/grabber/CMakeLists.txt
+++ b/pluginTemplates/grabber/CMakeLists.txt
@@ -8,7 +8,7 @@
 ###################################################################
 
 # this should be the first line of your project.
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 # here you give your project a unique name (replace MyGrabberPlugin by the desired project name of your plugin)
 set(target_name MyGrabberPlugin)

--- a/pluginTemplates/grabber/CMakeLists.txt
+++ b/pluginTemplates/grabber/CMakeLists.txt
@@ -7,11 +7,11 @@
 ###################################################################
 ###################################################################
 
-#here you give your project a unique name (replace MyGrabberPlugin by the desired project name of your plugin)
-set(target_name MyGrabberPlugin)
-
 # this should be the first line of your project.
-cmake_minimum_required(VERSION 3.1...3.15)
+cmake_minimum_required(VERSION 3.12)
+
+# here you give your project a unique name (replace MyGrabberPlugin by the desired project name of your plugin)
+set(target_name MyGrabberPlugin)
 
 #this is to automatically detect the SDK subfolder of the itom build directory.
 if(NOT EXISTS ${ITOM_SDK_DIR})

--- a/shape/CMakeLists.txt
+++ b/shape/CMakeLists.txt
@@ -23,7 +23,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 
 set(target_name itomShapeLib)
 project(${target_name})

--- a/shape/CMakeLists.txt
+++ b/shape/CMakeLists.txt
@@ -23,7 +23,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with itom. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.24)
 
 set(target_name itomShapeLib)
 project(${target_name})


### PR DESCRIPTION
This changes will fix the cmake warning ``cmake_minimum_required() should be called prior… to this top-level project()``