### PR TITLE
Default value by docstring generator

### DIFF
--- a/Qitom/codeEditor/modes/pyDocstringGenerator.cpp
+++ b/Qitom/codeEditor/modes/pyDocstringGenerator.cpp
@@ -715,8 +715,8 @@ QString PyDocstringGeneratorMode::generateNumpyDoc(
 
                     if (arg.m_isOptional)
                     {
-                        docs += QString("\n%1 : %2, optional\n    DESCRIPTION")
-                            .arg(arg.m_name).arg(typ);
+                        docs += QString("\n%1 : %2, optional\n    DESCRIPTION, by default %3")
+                            .arg(arg.m_name).arg(typ).arg(arg.m_defaultValue);
                     }
                     else
                     {

--- a/Qitom/codeEditor/modes/pyDocstringGenerator.cpp
+++ b/Qitom/codeEditor/modes/pyDocstringGenerator.cpp
@@ -557,9 +557,8 @@ void PyDocstringGeneratorMode::parseArgList(
         if (idx1 >= 0)
         {
             a.m_name = arg.left(idx1).trimmed();
-            a.m_type = idx2 >= 0 ?
-                arg.mid(idx1 + 1, idx2 - idx1 - 1).trimmed() :
-                arg.mid(idx1 + 1).trimmed();
+            a.m_type = idx2 >= 0 ? arg.sliced(idx1 + 1, idx2 - idx1 - 1).trimmed()
+                                 : arg.sliced(idx1 + 1).trimmed();
         }
         else if (idx2 >= 0)
         {
@@ -570,6 +569,11 @@ void PyDocstringGeneratorMode::parseArgList(
             a.m_name = arg.trimmed();
         }
 
+        if (a.m_isOptional)
+        {
+            a.m_defaultValue = arg.sliced(idx2 + 1).trimmed();
+        }
+
         if (count == 0 && expectSelfOrCls && (a.m_name == "self" || a.m_name == "cls"))
         {
             //pass
@@ -578,6 +582,8 @@ void PyDocstringGeneratorMode::parseArgList(
         {
             info.m_args.append(a);
         }
+
+
 
         count++;
     }
@@ -624,8 +630,9 @@ QString PyDocstringGeneratorMode::generateGoogleDoc(
 
                     if (arg.m_isOptional)
                     {
-                        docs += QString("\n    %1 (%2, optional): DESCRIPTION")
-                            .arg(arg.m_name).arg(typ);
+                        // Defaults notation according https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html
+                        docs += QString("\n    %1 (%2, optional): DESCRIPTION. Defaults to %3.")
+                            .arg(arg.m_name).arg(typ).arg(arg.m_defaultValue);
                     }
                     else
                     {

--- a/Qitom/codeEditor/modes/pyDocstringGenerator.h
+++ b/Qitom/codeEditor/modes/pyDocstringGenerator.h
@@ -81,9 +81,13 @@ protected:
 
     struct ArgInfo
     {
-        ArgInfo(const QString &name = "", const QString &type = "", bool isOptional = false) :
+        ArgInfo(
+            const QString& name = "",
+            const QString& type = "",
+            const QString& defaultValue = "", bool isOptional = false) :
             m_name(name),
             m_type(type),
+            m_defaultValue(defaultValue),
             m_isOptional(isOptional)
         {
 
@@ -91,6 +95,7 @@ protected:
 
         QString m_name;
         QString m_type;
+        QString m_defaultValue;
         bool m_isOptional;
     };
 


### PR DESCRIPTION
This PR adds the default values of optional arguments by the docstring generator.
Notation according to [google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) was implemented


```
def func(val1, val2: int, val3: float = 1.0, val4: str = None):
    """

    Args:
        val1 (TYPE): DESCRIPTION
        val2 (int): DESCRIPTION
        val3 (float, optional): DESCRIPTION. Defaults to 1.0.
        val4 (str, optional): DESCRIPTION. Defaults to None.
    """
```