### PR TITLE
Close itom by Python SystemExit exception (sys.exit(), exit(), quit() command)

### DIFF
--- a/Qitom/mainApplication.cpp
+++ b/Qitom/mainApplication.cpp
@@ -825,16 +825,16 @@ void MainApplication::setupApplication(const QStringList &scriptsToOpen, const Q
     m_pSplashScreen->showMessage(tr("load script editor organizer..."), Qt::AlignRight | Qt::AlignBottom, m_splashScreenTextColor);
     QCoreApplication::processEvents();
 
-    m_scriptEditorOrganizer = new ScriptEditorOrganizer(m_mainWin != NULL);
+    m_scriptEditorOrganizer = new ScriptEditorOrganizer(m_mainWin != nullptr);
     AppManagement::setScriptEditorOrganizer(m_scriptEditorOrganizer); //qobject_cast<QObject*>(scriptEditorOrganizer);
 
     qDebug("..script editor started");
 
-    if (m_mainWin != NULL)
+    if (m_mainWin != nullptr)
     {
         connect(m_scriptEditorOrganizer, SIGNAL(addScriptDockWidgetToMainWindow(AbstractDockWidget*,Qt::DockWidgetArea)), m_mainWin, SLOT(addAbstractDock(AbstractDockWidget*, Qt::DockWidgetArea)));
         connect(m_scriptEditorOrganizer, SIGNAL(removeScriptDockWidgetFromMainWindow(AbstractDockWidget*)), m_mainWin, SLOT(removeAbstractDock(AbstractDockWidget*)));
-        connect(m_mainWin, SIGNAL(mainWindowCloseRequest()), this, SLOT(mainWindowCloseRequest()));
+        connect(m_mainWin, &MainWindow::mainWindowCloseRequest, this, &MainApplication::mainWindowCloseRequest);
 
         if (m_scriptEditorOrganizer)
         {
@@ -1092,7 +1092,7 @@ void MainApplication::finalizeApplication()
 /*!
     \sa MainWindow
 */
-void MainApplication::mainWindowCloseRequest()
+void MainApplication::mainWindowCloseRequest(bool considerPythonBusy)
 {
     RetVal retValue(retOk);
 
@@ -1100,12 +1100,12 @@ void MainApplication::mainWindowCloseRequest()
     settings->beginGroup("MainWindow");
 
     bool pythonStopped = false;
-    bool closeRequestCanceled = false;
+    bool closeRequestCancelled = false;
     int dialogRequest = -1;
 
-    if (m_pyEngine != NULL && m_pyEngine->isPythonBusy())
+    if (considerPythonBusy && m_pyEngine != nullptr && m_pyEngine->isPythonBusy())
     {
-        DialogCloseItom *dialog = new DialogCloseItom(NULL);
+        DialogCloseItom *dialog = new DialogCloseItom(nullptr);
 
         int dialogRequest = dialog->exec();
 
@@ -1115,7 +1115,7 @@ void MainApplication::mainWindowCloseRequest()
         }
         else if (dialogRequest == QDialog::Rejected)
         {
-            closeRequestCanceled = true;
+            closeRequestCancelled = true;
         }
 
         DELETE_AND_SET_NULL(dialog);
@@ -1158,7 +1158,7 @@ void MainApplication::mainWindowCloseRequest()
         }
     }
 
-    if (!retValue.containsError() && !closeRequestCanceled)
+    if (!retValue.containsError() && !closeRequestCancelled)
     {
         settings->endGroup();
         delete settings;

--- a/Qitom/mainApplication.h
+++ b/Qitom/mainApplication.h
@@ -1,7 +1,7 @@
 /* ********************************************************************
     itom software
     URL: http://www.uni-stuttgart.de/ito
-    Copyright (C) 2020, Institut fuer Technische Optik (ITO),
+    Copyright (C) 2023, Institut fuer Technische Optik (ITO),
     Universitaet Stuttgart, Germany
 
     This file is part of itom.
@@ -20,8 +20,7 @@
     along with itom. If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************** */
 
-#ifndef MAINAPPLICATION_H
-#define MAINAPPLICATION_H
+#pragma once
 
 #include "python/pythonEngineInc.h"
 #include "python/qDebugStream.h"
@@ -109,9 +108,7 @@ class MainApplication : public QObject
 
     public slots:
         void _propertiesChanged() { emit propertiesChanged(); }
-        void mainWindowCloseRequest();
+        void mainWindowCloseRequest(bool considerPythonBusy);
 };
 
 } //end namespace ito
-
-#endif

--- a/Qitom/python/pythonEngine.cpp
+++ b/Qitom/python/pythonEngine.cpp
@@ -1859,8 +1859,7 @@ ito::RetVal PythonEngine::runString(const QString &command)
         {
             if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_SystemExit))
             {
-                std::cerr << "wish to exit (not possible yet)\n" << std::endl;
-                retValue += RetVal(retError, 2, tr("exiting desired.").toLatin1().data());
+                retValue += handlePythonSysExit();
             }
             else
             {
@@ -1945,8 +1944,7 @@ ito::RetVal PythonEngine::runPyFile(const QString &pythonFileName)
                 {
                     if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_SystemExit))
                     {
-                        std::cerr << "wish to exit (not possible yet)\n" << std::endl;
-                        retValue += RetVal(retError);
+                        retValue += handlePythonSysExit();
                     }
                     else
                     {
@@ -1972,8 +1970,7 @@ ito::RetVal PythonEngine::runPyFile(const QString &pythonFileName)
                     {
                         if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_SystemExit))
                         {
-                            std::cerr << "wish to exit (not possible yet)\n" << std::endl;
-                            retValue += RetVal(retError);
+                            retValue += handlePythonSysExit();
                         }
                         else
                         {
@@ -2038,8 +2035,7 @@ ito::RetVal PythonEngine::runPyFile(const QString &pythonFileName)
             {
                 if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_SystemExit))
                 {
-                    std::cerr << "wish to exit (not possible yet)\n" << std::endl;
-                    retValue += RetVal(retError);
+                    retValue += handlePythonSysExit();
                 }
                 else
                 {
@@ -2208,8 +2204,7 @@ ito::RetVal PythonEngine::debugFunction(PyObject *callable, PyObject *argTuple, 
         {
             if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_SystemExit))
             {
-                std::cerr << "wish to exit (not possible yet)\n" << std::endl;
-                retValue += RetVal(retError);
+                retValue += handlePythonSysExit();
             }
             else
             {
@@ -2323,8 +2318,7 @@ ito::RetVal PythonEngine::debugFile(const QString &pythonFileName)
         {
             if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_SystemExit))
             {
-                std::cerr << "wish to exit (not possible yet)\n" << std::endl;
-                retValue += RetVal(retError);
+                retValue += handlePythonSysExit();
             }
             else
             {
@@ -2438,12 +2432,11 @@ ito::RetVal PythonEngine::debugString(const QString &command)
 
         clearDbgCmdLoop();
 
-        if (result == NULL) //!< syntax error
+        if (result == nullptr) //!< syntax error
         {
             if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_SystemExit))
             {
-                std::cerr << "wish to exit (not possible yet)\n" << std::endl;
-                retValue += RetVal(retError);
+                retValue += handlePythonSysExit();
             }
             else
             {
@@ -2452,7 +2445,7 @@ ito::RetVal PythonEngine::debugString(const QString &command)
                 modifyTracebackDepth(3, true);
                 PyErr_PrintEx(0);
 
-                if (oldTBLimit != NULL)
+                if (oldTBLimit != nullptr)
                 {
                     PySys_SetObject("tracebacklimit", oldTBLimit);
                 }
@@ -2484,7 +2477,28 @@ ito::RetVal PythonEngine::debugString(const QString &command)
     return retValue;
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------
+ito::RetVal PythonEngine::handlePythonSysExit()
+{
+    QSettings settings(AppManagement::getSettingsFile(), QSettings::IniFormat);
+    settings.beginGroup("Python");
+    bool closeItom = settings.value("closeItomWithPySysExit", false).toBool();
+    settings.endGroup();
+
+    if (closeItom)
+    {
+        QMetaObject::invokeMethod(AppManagement::getMainApplication(), "mainWindowCloseRequest", Q_ARG(bool, false));
+        std::cerr << tr("close itom due to sys.exit()").toLatin1().data() << "\n" << std::endl;
+        return ito::RetVal(ito::retError, 0, "Close itom due to Python sys.exit()");
+    }
+    else
+    {
+        std::cerr << tr("sys.exit() is ignored. If itom should be closed, enable it in the itom properties dialog.").toLatin1().data() << "\n" << std::endl;
+        return ito::RetVal(ito::retError, 0, "sys.exit() ignored.");
+    }
+}
+
+//-------------------------------------------------------------------------------------
 bool PythonEngine::tryToLoadJediIfNotYetDone()
 {
     if (!m_jediRunner.isNull())

--- a/Qitom/python/pythonEngine.h
+++ b/Qitom/python/pythonEngine.h
@@ -1,7 +1,7 @@
 /* ********************************************************************
     itom software
     URL: http://www.uni-stuttgart.de/ito
-    Copyright (C) 2020, Institut fuer Technische Optik (ITO),
+    Copyright (C) 2023, Institut fuer Technische Optik (ITO),
     Universitaet Stuttgart, Germany
 
     This file is part of itom.
@@ -20,8 +20,7 @@
     along with itom. If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************** */
 
-#ifndef PYTHONENGINE_H
-#define PYTHONENGINE_H
+#pragma once
 
 /*if you add any include to this file you will DIE an immediate, horrible, painful death*/
 
@@ -280,6 +279,7 @@ private:
     PyObject* getAndCheckIdentifier(const QString &identifier, ito::RetVal &retval) const;
 
 	QVariantMap checkCodeCheckerRequirements();
+    ito::RetVal handlePythonSysExit();
 
 	struct CodeCheckerOptions
 	{
@@ -441,6 +441,3 @@ public slots:
 };
 
 } //end namespace ito
-
-
-#endif

--- a/Qitom/ui/widgetPropPythonGeneral.cpp
+++ b/Qitom/ui/widgetPropPythonGeneral.cpp
@@ -1,7 +1,7 @@
 /* ********************************************************************
     itom software
     URL: http://www.uni-stuttgart.de/ito
-    Copyright (C) 2020, Institut fuer Technische Optik (ITO),
+    Copyright (C) 2023, Institut fuer Technische Optik (ITO),
     Universitaet Stuttgart, Germany
 
     This file is part of itom.
@@ -104,6 +104,10 @@ void WidgetPropPythonGeneral::readSettings()
             on_cbbPyUse3rdPartyPresets_currentTextChanged(it.key());
         }
     }
+
+    bool closeItomWithPySysExit = settings.value("closeItomWithPySysExit", false).toBool();
+    ui.checkCloseItomByPySysExit->setChecked(closeItomWithPySysExit);
+
     settings.endGroup();
 }
 
@@ -135,6 +139,10 @@ void WidgetPropPythonGeneral::writeSettings()
 
     settings.setValue("python3rdPartyHelperUse",ui.cbPyUse3rdPartyHelp->isChecked());
     settings.setValue("python3rdPartyHelperCommand", ui.lePyUse3rdPartyCommand->text());
+
+    bool closeItomWithPySysExit = ui.checkCloseItomByPySysExit->isChecked();
+    settings.setValue("closeItomWithPySysExit", closeItomWithPySysExit);
+
     settings.endGroup();
 
 }

--- a/Qitom/ui/widgetPropPythonGeneral.ui
+++ b/Qitom/ui/widgetPropPythonGeneral.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>382</width>
-    <height>475</height>
+    <height>509</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -45,6 +45,22 @@
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Python sys.exit() command</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="QCheckBox" name="checkCloseItomByPySysExit">
+        <property name="text">
+         <string>Close the itom application with Python sys.exit() command</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>

--- a/Qitom/widgets/mainWindow.cpp
+++ b/Qitom/widgets/mainWindow.cpp
@@ -876,7 +876,7 @@ void MainWindow::connectPythonMessageBox(QListWidget* pythonMessageBox)
 */
 void MainWindow::closeEvent(QCloseEvent* event)
 {
-    emit(mainWindowCloseRequest());
+    emit(mainWindowCloseRequest(true));
     event->ignore(); //!< if mainWindowCloseRequest is handled and accepted by mainApplication,
                      //!< MainWindow will be destroyed
 }
@@ -2826,7 +2826,7 @@ void MainWindow::mnuShowLoadedPlugins()
 void MainWindow::mnuExitApplication()
 {
     // does not call the closeEvent-method!
-    emit(mainWindowCloseRequest());
+    emit(mainWindowCloseRequest(true));
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------

--- a/Qitom/widgets/mainWindow.h
+++ b/Qitom/widgets/mainWindow.h
@@ -1,7 +1,7 @@
 /* ********************************************************************
     itom software
     URL: http://www.uni-stuttgart.de/ito
-    Copyright (C) 2020, Institut fuer Technische Optik (ITO),
+    Copyright (C) 2023, Institut fuer Technische Optik (ITO),
     Universitaet Stuttgart, Germany
 
     This file is part of itom.
@@ -20,8 +20,7 @@
     along with itom. If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************** */
 
-#ifndef MAINWINDOW_H
-#define MAINWINDOW_H
+#pragma once
 
 #include "workspaceDockWidget.h"
 #include "callStackDockWidget.h"
@@ -147,7 +146,7 @@ private:
     QMap<QString, QPointer<WidgetInfoBox> > m_infoBoxWidgets;
 
 signals:
-    void mainWindowCloseRequest();  /*!<  signal emitted if user would like to close the main window and therefore the entire application */
+    void mainWindowCloseRequest(bool considerPythonBusy);  /*!<  signal emitted if user would like to close the main window and therefore the entire application */
     void pythonDebugCommand(tPythonDbgCmd cmd); /*!<  will be received by PythonThread, directly */
     void pythonSetAutoReloadSettings(bool enabled, bool checkFile, bool checkCmd, bool checkFct);
 
@@ -236,5 +235,3 @@ private slots:
 };
 
 } //end namespace ito
-
-#endif

--- a/docs/userDoc/source/04_itom_gui/propertyDialog.rst
+++ b/docs/userDoc/source/04_itom_gui/propertyDialog.rst
@@ -150,6 +150,9 @@ General
 * Use the drop-down menu to define if changes in scripts should automatically
   be saved before executing the script.
 
+* You can select if a Python **SystemExit** exception, triggered by **exit()**, **sys.exit()** or **quit()**,
+  will totally close the itom application or if the script execution is only stopped.
+
 * Every version of |itom| is compiled against a certain version of Python.
   At runtime, Python can be loaded from different directories, which
   can be given in the 2nd part of this


### PR DESCRIPTION
Up to now, the Python SystemExit exception, raised by **sys.exit()**, **exit()**, **quit()**, stops the script execution but does not close the itom application. By this pull request, a new setting value is added to the Python tab of the itom property dialog. If the checkbox is set, itom will be closed if this exception is raised. The default is the previous behaviour (no shutdown).