### PR TITLE
Support for ANSI escape sequences in console widget

### DIFF
--- a/Qitom/codeEditor/syntaxHighlighter/pythonSyntaxHighlighter.cpp
+++ b/Qitom/codeEditor/syntaxHighlighter/pythonSyntaxHighlighter.cpp
@@ -48,6 +48,7 @@
 #include "../managers/panelsManager.h"
 #include "../modes/caretLineHighlight.h"
 #include "../utils/utils.h"
+#include "../textBlockUserData.h"
 
 #include <qdebug.h>
 #include <iostream>
@@ -120,15 +121,72 @@ hasNextMatch(const QList<QPair<QRegularExpressionMatch, QStringList> > &matches,
 }
 
 
-void PythonSyntaxHighlighter::default_highlight_block(const QString &text, bool outputNotError)
+void PythonSyntaxHighlighter::default_highlight_block(const QString &text, const TextBlockUserData *textBlockUserData)
 {
-    if (outputNotError)
+    bool outputNotError = textBlockUserData->m_syntaxStyle == TextBlockUserData::StyleOutput;
+
+    QTextCharFormat defaultFormat = getFormatFromStyle(
+        outputNotError ? StyleItem::KeyStreamOutput : StyleItem::KeyStreamError
+    );
+
+    if (textBlockUserData->m_ansiTextCharFormats.isNull())
     {
-        setFormat(0, text.size(), getFormatFromStyle(StyleItem::KeyStreamOutput));
+        // no special ansi text char formats: apply defaultFormat everywhere
+        setFormat(0, text.size(), defaultFormat);
     }
     else
     {
-        setFormat(0, text.size(), getFormatFromStyle(StyleItem::KeyStreamError));
+        int curCol = 0;
+        int count;
+        QTextCharFormat format;
+        QBrush brush;
+
+        foreach(const ito::TextBlockUserData::AnsiTextCharFormat &item, *(textBlockUserData->m_ansiTextCharFormats))
+        {
+            if (item.colStart > curCol)
+            {
+                count = item.colStart - curCol;
+                setFormat(0, count, defaultFormat);
+                curCol += count;
+            }
+
+            count = item.colEnd - item.colStart;
+            format = defaultFormat;
+
+            // only modify the font style if bold or underline is set to true
+            if (item.textBold)
+            {
+                format.font().setBold(true);
+            }
+
+            if (item.textUnderline)
+            {
+                format.font().setUnderline(true);
+            }
+
+            if (item.textColor.spec() != QColor::Invalid)
+            {
+                brush = format.foreground();
+                brush.setColor(item.textColor);
+                format.setForeground(brush);
+            }
+
+            if (item.backgroundColor.spec() != QColor::Invalid)
+            {
+                brush = format.background();
+                brush.setColor(item.backgroundColor);
+                format.setBackground(brush);
+            }
+
+            setFormat(item.colStart, count, format);
+            curCol += count;
+        }
+
+        if (curCol < text.size())
+        {
+            count = text.size() - curCol;
+            setFormat(curCol, count, defaultFormat);
+        }
     }
 }
 //-------------------------------------------------------------------

--- a/Qitom/codeEditor/syntaxHighlighter/pythonSyntaxHighlighter.cpp
+++ b/Qitom/codeEditor/syntaxHighlighter/pythonSyntaxHighlighter.cpp
@@ -154,13 +154,18 @@ void PythonSyntaxHighlighter::default_highlight_block(const QString &text, const
             format = defaultFormat;
 
             // only modify the font style if bold or underline is set to true
-            if (item.textBold || item.textUnderline)
+            if (item.textBold || item.textUnderline || item.textItalic)
             {
                 QFont font = format.font();
 
                 if (item.textBold)
                 {
                     font.setWeight(QFont::Bold);
+                }
+
+                if (item.textItalic)
+                {
+                    font.setItalic(true);
                 }
 
                 if (item.textUnderline)

--- a/Qitom/codeEditor/syntaxHighlighter/pythonSyntaxHighlighter.cpp
+++ b/Qitom/codeEditor/syntaxHighlighter/pythonSyntaxHighlighter.cpp
@@ -154,14 +154,21 @@ void PythonSyntaxHighlighter::default_highlight_block(const QString &text, const
             format = defaultFormat;
 
             // only modify the font style if bold or underline is set to true
-            if (item.textBold)
+            if (item.textBold || item.textUnderline)
             {
-                format.font().setBold(true);
-            }
+                QFont font = format.font();
 
-            if (item.textUnderline)
-            {
-                format.font().setUnderline(true);
+                if (item.textBold)
+                {
+                    font.setWeight(QFont::Bold);
+                }
+
+                if (item.textUnderline)
+                {
+                    font.setUnderline(true);
+                }
+
+                format.setFont(font);
             }
 
             if (item.textColor.spec() != QColor::Invalid)

--- a/Qitom/codeEditor/syntaxHighlighter/pythonSyntaxHighlighter.h
+++ b/Qitom/codeEditor/syntaxHighlighter/pythonSyntaxHighlighter.h
@@ -78,7 +78,7 @@ public:
     */
     void highlight_block(const QString &text, QTextBlock &block);
 
-    void default_highlight_block(const QString &text, bool outputNotError);
+    void default_highlight_block(const QString &text, const TextBlockUserData *textBlockUserData);
 
     virtual void rehighlight();
 

--- a/Qitom/codeEditor/syntaxHighlighter/syntaxHighlighterBase.cpp
+++ b/Qitom/codeEditor/syntaxHighlighter/syntaxHighlighterBase.cpp
@@ -127,10 +127,11 @@ void SyntaxHighlighterBase::highlightBlock(const QString &text)
         CodeEditor *e = editor();
 
         //qDebug() << current_block.blockNumber();
-        TextBlockUserData *userData = e->getTextBlockUserData(current_block, false);
+        const TextBlockUserData *userData = e->getTextBlockUserData(current_block, false);
+
         if (userData && userData->m_syntaxStyle != TextBlockUserData::StylePython)
         {
-            default_highlight_block(text, userData->m_syntaxStyle == TextBlockUserData::StyleOutput);
+            default_highlight_block(text, userData);
         }
         else
         {

--- a/Qitom/codeEditor/syntaxHighlighter/syntaxHighlighterBase.h
+++ b/Qitom/codeEditor/syntaxHighlighter/syntaxHighlighterBase.h
@@ -91,7 +91,7 @@ public:
     */
     virtual void highlight_block(const QString &text, QTextBlock &block) = 0;
 
-    virtual void default_highlight_block(const QString &text, bool outputNotError) = 0;
+    virtual void default_highlight_block(const QString &text, const TextBlockUserData *textBlockUserData) = 0;
 
     virtual void rehighlight();
 

--- a/Qitom/codeEditor/textBlockUserData.h
+++ b/Qitom/codeEditor/textBlockUserData.h
@@ -73,6 +73,16 @@ public:
         StyleError
     };
 
+    struct AnsiTextCharFormat 
+    {
+        int colStart; // inclusive, zero-based
+        int colEnd; // inclusive, zero-based
+        QColor textColor;
+        QColor backgroundColor;
+        bool textBold; /* true: bold, false: do not change the current default style */
+        bool textUnderline; /* true: underline, false: do not change the current default style */
+    };
+
     TextBlockUserData(CodeEditor *editor);
 
     virtual ~TextBlockUserData();
@@ -89,7 +99,9 @@ public:
 
     bool m_bookmark;
 
-    QSharedPointer<TextBlockUserData> m_syntaxStack; //e.g. for python syntax highlighter
+    // this is only not nullptr, if special ansi text char formats have been encountered for parts of this text block
+    // if given, this must be sorted by anscending startcols
+    QSharedPointer<QList<AnsiTextCharFormat>> m_ansiTextCharFormats;
 
     int m_currentLineIdx;
 

--- a/Qitom/codeEditor/textBlockUserData.h
+++ b/Qitom/codeEditor/textBlockUserData.h
@@ -79,8 +79,9 @@ public:
         int colEnd; // inclusive, zero-based
         QColor textColor;
         QColor backgroundColor;
-        bool textBold; /* true: bold, false: do not change the current default style */
-        bool textUnderline; /* true: underline, false: do not change the current default style */
+        bool textBold; /* true: bold, false: do not change the default */
+        bool textUnderline; /* true: underline, false: do not change the default */
+        bool textItalic; /* true: italic, false: do not change the default */
     };
 
     TextBlockUserData(CodeEditor *editor);

--- a/Qitom/ui/widgetPropConsoleGeneral.cpp
+++ b/Qitom/ui/widgetPropConsoleGeneral.cpp
@@ -1,7 +1,7 @@
 /* ********************************************************************
     itom software
     URL: http://www.uni-stuttgart.de/ito
-    Copyright (C) 2020, Institut fuer Technische Optik (ITO),
+    Copyright (C) 2024, Institut fuer Technische Optik (ITO),
     Universitaet Stuttgart, Germany
 
     This file is part of itom.
@@ -28,19 +28,19 @@
 namespace ito
 {
 
-//----------------------------------------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------
 WidgetPropConsoleGeneral::WidgetPropConsoleGeneral(QWidget *parent) :
     AbstractPropertyPageWidget(parent)
 {
     ui.setupUi(this);
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------
 WidgetPropConsoleGeneral::~WidgetPropConsoleGeneral()
 {
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------
 void WidgetPropConsoleGeneral::readSettings()
 {
     QSettings settings(AppManagement::getSettingsFile(), QSettings::IniFormat);
@@ -48,11 +48,12 @@ void WidgetPropConsoleGeneral::readSettings()
 
     ui.checkBoxFormatCopyCode->setChecked(settings.value("formatCopyCutCode", true).toBool());
     ui.checkBoxFormatPastCode->setChecked(settings.value("formatPasteAndDropCode", true).toBool());
+    ui.checkConsiderAnsiEscapeSequences->setChecked(settings.value("considerAnsiEscapeSequences", true).toBool());
 
     settings.endGroup();
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------
 void WidgetPropConsoleGeneral::writeSettings()
 {
     QSettings settings(AppManagement::getSettingsFile(), QSettings::IniFormat);
@@ -60,6 +61,7 @@ void WidgetPropConsoleGeneral::writeSettings()
 
     settings.setValue("formatCopyCutCode", ui.checkBoxFormatCopyCode->isChecked());
     settings.setValue("formatPasteAndDropCode", ui.checkBoxFormatPastCode->isChecked());
+    settings.setValue("considerAnsiEscapeSequences", ui.checkConsiderAnsiEscapeSequences->isChecked());
 
     settings.endGroup();
 }

--- a/Qitom/ui/widgetPropConsoleGeneral.ui
+++ b/Qitom/ui/widgetPropConsoleGeneral.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>611</width>
+    <width>599</width>
     <height>506</height>
    </rect>
   </property>
@@ -60,6 +60,25 @@
        <widget class="QCheckBox" name="checkBoxFormatPastCode">
         <property name="text">
          <string>Modify text in clipboard before pasting to console. </string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>ANSI Escape Sequences</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QCheckBox" name="checkConsiderAnsiEscapeSequences">
+        <property name="text">
+         <string>Remove ANSI Escape Sequences from output text and apply formatting, if possible.</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/Qitom/widgets/consoleWidget.cpp
+++ b/Qitom/widgets/consoleWidget.cpp
@@ -1376,12 +1376,12 @@ void ConsoleWidget::updateAnsiTextCharFormat(
 
             if (argnums[idx + 1] == 1)
             {
-                format.backgroundColor = colors[ansiCodeId - 30].lighter(150);
+                format.backgroundColor = colors[ansiCodeId - 40].lighter(150);
                 idx++;
             }
             else
             {
-                format.backgroundColor = colors[ansiCodeId - 30];
+                format.backgroundColor = colors[ansiCodeId - 40];
             }
         }
         else if (ansiCodeId == 48)

--- a/Qitom/widgets/consoleWidget.h
+++ b/Qitom/widgets/consoleWidget.h
@@ -85,8 +85,6 @@ public slots:
 signals:
     void wantToCopy();
     void sendToLastCommand(QString cmd);
-    void sendToPythonMessage(QString cmd);
-
 
 protected:
     virtual bool keyPressInternalEvent(QKeyEvent *event);
@@ -192,6 +190,7 @@ private:
 
     ito::TextBlockUserData::AnsiTextCharFormat m_recentAnsiTextCharFormat;
     QRegularExpression m_ansiEscapeSeqRegExp;
+    bool m_considerAnsiEscapeSequences;
 
     static const QString longLineWrapPrefix;
 

--- a/Qitom/widgets/consoleWidget.h
+++ b/Qitom/widgets/consoleWidget.h
@@ -154,7 +154,7 @@ private:
     void disableInputTextMode();
 
     QSharedPointer<QList<ito::TextBlockUserData::AnsiTextCharFormat>> parseReceiveStreamBufferForAnsiCodes(const QString &inputText, QString &strippedText);
-    void updateAnsiTextCharFormat(ito::TextBlockUserData::AnsiTextCharFormat &format, int ansiCodeId, int ansiCodeSuffix1 = 0, int ansiCodeSuffix2 = 0);
+    void updateAnsiTextCharFormat(ito::TextBlockUserData::AnsiTextCharFormat &format, const QString &args);
 
     int m_startLineBeginCmd; //!< zero-based, first-line of actual (not evaluated command), last line which starts with ">>", -1: no command active
 

--- a/Qitom/widgets/consoleWidget.h
+++ b/Qitom/widgets/consoleWidget.h
@@ -152,7 +152,7 @@ private:
     void disableInputTextMode();
 
     QSharedPointer<QList<ito::TextBlockUserData::AnsiTextCharFormat>> parseReceiveStreamBufferForAnsiCodes(const QString &inputText, QString &strippedText);
-    void updateAnsiTextCharFormat(ito::TextBlockUserData::AnsiTextCharFormat &format, const QString &args);
+    void updateAnsiTextCharFormat(ito::TextBlockUserData::AnsiTextCharFormat &format, const QString &mainChar, const QString &args);
 
     int m_startLineBeginCmd; //!< zero-based, first-line of actual (not evaluated command), last line which starts with ">>", -1: no command active
 

--- a/Qitom/widgets/consoleWidget.h
+++ b/Qitom/widgets/consoleWidget.h
@@ -1,7 +1,7 @@
 /* ********************************************************************
     itom software
     URL: http://www.uni-stuttgart.de/ito
-    Copyright (C) 2020, Institut fuer Technische Optik (ITO),
+    Copyright (C) 2024, Institut fuer Technische Optik (ITO),
     Universitaet Stuttgart, Germany
 
     This file is part of itom.
@@ -44,10 +44,9 @@
 #include <qsettings.h>
 #include <qtimer.h>
 #include <qelapsedtimer.h>
+#include <qregularexpression.h>
 
-QT_BEGIN_NAMESPACE
 
-QT_END_NAMESPACE
 
 namespace ito
 {
@@ -59,7 +58,7 @@ class ConsoleWidget : public AbstractCodeEditorWidget
     Q_OBJECT
 
 public:
-    ConsoleWidget(QWidget* parent = NULL);
+    ConsoleWidget(QWidget* parent = nullptr);
     ~ConsoleWidget();
 
     static const QString lineBreak;
@@ -154,6 +153,9 @@ private:
     void enableInputTextMode();
     void disableInputTextMode();
 
+    QSharedPointer<QList<ito::TextBlockUserData::AnsiTextCharFormat>> parseReceiveStreamBufferForAnsiCodes();
+    void updateAnsiTextCharFormat(ito::TextBlockUserData::AnsiTextCharFormat &format, int ansiCodeId, int ansiCodeSuffix1 = 0, int ansiCodeSuffix2 = 0);
+
     int m_startLineBeginCmd; //!< zero-based, first-line of actual (not evaluated command), last line which starts with ">>", -1: no command active
 
     DequeCommandList *m_pCmdList;
@@ -187,6 +189,9 @@ private:
     QMap<QString, QAction*> m_contextMenuActions;
 
     InputTextMode m_inputTextMode;
+
+    ito::TextBlockUserData::AnsiTextCharFormat m_recentAnsiTextCharFormat;
+    QRegularExpression m_ansiEscapeSeqRegExp;
 
     static const QString longLineWrapPrefix;
 

--- a/Qitom/widgets/consoleWidget.h
+++ b/Qitom/widgets/consoleWidget.h
@@ -153,7 +153,7 @@ private:
     void enableInputTextMode();
     void disableInputTextMode();
 
-    QSharedPointer<QList<ito::TextBlockUserData::AnsiTextCharFormat>> parseReceiveStreamBufferForAnsiCodes();
+    QSharedPointer<QList<ito::TextBlockUserData::AnsiTextCharFormat>> parseReceiveStreamBufferForAnsiCodes(const QString &inputText, QString &strippedText);
     void updateAnsiTextCharFormat(ito::TextBlockUserData::AnsiTextCharFormat &format, int ansiCodeId, int ansiCodeSuffix1 = 0, int ansiCodeSuffix2 = 0);
 
     int m_startLineBeginCmd; //!< zero-based, first-line of actual (not evaluated command), last line which starts with ">>", -1: no command active

--- a/Qitom/widgets/consoleWidget.h
+++ b/Qitom/widgets/consoleWidget.h
@@ -151,7 +151,15 @@ private:
     void enableInputTextMode();
     void disableInputTextMode();
 
-    QSharedPointer<QList<ito::TextBlockUserData::AnsiTextCharFormat>> parseReceiveStreamBufferForAnsiCodes(const QString &inputText, QString &strippedText);
+    QList<ito::TextBlockUserData::AnsiTextCharFormat> parseReceiveStreamBufferForAnsiCodes(const QString &inputText, QString &strippedText);
+    QList<QSharedPointer<QList<ito::TextBlockUserData::AnsiTextCharFormat>>> handleTextLinesAndSplitLongLines(
+        QString &text, 
+        const QList<ito::TextBlockUserData::AnsiTextCharFormat> &ansiTextCharFormat, 
+        bool smartSplitting);
+    QList<QSharedPointer<QList<ito::TextBlockUserData::AnsiTextCharFormat>>> splitLongLinesText(
+        QString &text,
+        const QSharedPointer<QList<ito::TextBlockUserData::AnsiTextCharFormat>> &ansiTextCharFormat,
+        bool smartSplitting);
     void updateAnsiTextCharFormat(ito::TextBlockUserData::AnsiTextCharFormat &format, const QString &mainChar, const QString &args);
 
     int m_startLineBeginCmd; //!< zero-based, first-line of actual (not evaluated command), last line which starts with ">>", -1: no command active

--- a/Qitom/widgets/mainWindow.cpp
+++ b/Qitom/widgets/mainWindow.cpp
@@ -633,12 +633,6 @@ MainWindow::~MainWindow()
             SLOT(addLastCommand(QString)));
     }
 
-    /*    if (m_pythonMessageDock && m_console)
-        {
-            disconnect(m_console, SIGNAL(sendToPythonMessage(QString)), m_pythonMessageDock,
-       SLOT(addPythonMessage(QString)));
-        }*/
-
     DELETE_AND_SET_NULL(m_pAIManagerWidget);
     DELETE_AND_SET_NULL(m_fileSystemDock);
     DELETE_AND_SET_NULL(m_helpDock);
@@ -852,16 +846,6 @@ void MainWindow::scriptStatusBarInformationChanged(
             m_pStatusLblScriptInfo->setText("");
         }
     }
-}
-
-//----------------------------------------------------------------------------------------------------------------------------------
-void MainWindow::connectPythonMessageBox(QListWidget* pythonMessageBox)
-{
-    connect(
-        m_console,
-        SIGNAL(sendToPythonMessage(QString)),
-        pythonMessageBox,
-        SLOT(addNewMessage(QString)));
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------

--- a/Qitom/widgets/mainWindow.h
+++ b/Qitom/widgets/mainWindow.h
@@ -153,7 +153,6 @@ signals:
 public slots:
     void addAbstractDock(AbstractDockWidget* dockWidget, Qt::DockWidgetArea area = Qt::TopDockWidgetArea);
     void removeAbstractDock(AbstractDockWidget* dockWidget);
-    void connectPythonMessageBox(QListWidget* pythonMessageBox);
 
     void pythonStateChanged(tPythonTransitions pyTransition);
 

--- a/demo/itom/basics/demo_ansiEscapeSequencesOutput.py
+++ b/demo/itom/basics/demo_ansiEscapeSequencesOutput.py
@@ -1,0 +1,20 @@
+# this demo shows some possibilites of ANSI escape codes:
+
+# Change the text color
+
+# set the text colors to pre-defined values, followed by a reset
+print(u"\u001b[30m A \u001b[31m B \u001b[32m C \u001b[33m D \u001b[0mText after reset")
+print(u"\u001b[34m E \u001b[35m F \u001b[36m G \u001b[37m H \u001b[0mText after reset")
+
+# use the prefix 1 to choose are more lighter text color
+print(u"\u001b[30;1m A \u001b[31;1m B \u001b[32;1m C \u001b[33;1m D \u001b[0mText after reset")
+print(u"\u001b[34;1m E \u001b[35;1m F \u001b[36;1m G \u001b[37;1m H \u001b[0mText after reset")
+
+# now the same with the background color
+print(u"\u001b[40m A \u001b[41m B \u001b[42m C \u001b[43m D \u001b[0mText after reset")
+print(u"\u001b[44m E \u001b[45m F \u001b[46m G \u001b[47m H \u001b[0mText after reset")
+print(u"\u001b[40;1m A \u001b[41;1m B \u001b[42;1m C \u001b[43;1m D \u001b[0mText after reset")
+print(u"\u001b[44;1m E \u001b[45;1m F \u001b[46;1m G \u001b[47;1m H \u001b[0mText after reset")
+
+# use text bold, underline, italic or combine them
+print(u"\u001b[1;3;4mText bold, underline and italic \u001b[22mRemove bold only \u001b[23;1mRemove underline and set bold again \u001b[0mReset all")

--- a/demo/itom/basics/demo_ansiEscapeSequencesOutput.py
+++ b/demo/itom/basics/demo_ansiEscapeSequencesOutput.py
@@ -27,5 +27,5 @@ print("\u001b[44;1m E \u001b[45;1m F \u001b[46;1m G \u001b[47;1m H \u001b[0mText
 # use text bold, underline, italic or combine them
 print(
     "\u001b[1;3;4mText bold, underline and italic \u001b[22mRemove bold only "
-    "\u001b[23;1mRemove underline and set bold again \u001b[0mReset all"
+    "\u001b[23;1mRemove italic and set bold again \u001b[0mReset all"
 )

--- a/demo/itom/basics/demo_ansiEscapeSequencesOutput.py
+++ b/demo/itom/basics/demo_ansiEscapeSequencesOutput.py
@@ -1,20 +1,31 @@
-# this demo shows some possibilites of ANSI escape codes:
+"""ANSI escape codes
+===================
 
+This demo shows some possibilites of ANSI escape codes."""
+
+###############################################################################
 # Change the text color
 
+###############################################################################
 # set the text colors to pre-defined values, followed by a reset
-print(u"\u001b[30m A \u001b[31m B \u001b[32m C \u001b[33m D \u001b[0mText after reset")
-print(u"\u001b[34m E \u001b[35m F \u001b[36m G \u001b[37m H \u001b[0mText after reset")
+print("\u001b[30m A \u001b[31m B \u001b[32m C \u001b[33m D \u001b[0mText after reset")
+print("\u001b[34m E \u001b[35m F \u001b[36m G \u001b[37m H \u001b[0mText after reset")
 
+###############################################################################
 # use the prefix 1 to choose are more lighter text color
-print(u"\u001b[30;1m A \u001b[31;1m B \u001b[32;1m C \u001b[33;1m D \u001b[0mText after reset")
-print(u"\u001b[34;1m E \u001b[35;1m F \u001b[36;1m G \u001b[37;1m H \u001b[0mText after reset")
+print("\u001b[30;1m A \u001b[31;1m B \u001b[32;1m C \u001b[33;1m D \u001b[0mText after reset")
+print("\u001b[34;1m E \u001b[35;1m F \u001b[36;1m G \u001b[37;1m H \u001b[0mText after reset")
 
+###############################################################################
 # now the same with the background color
-print(u"\u001b[40m A \u001b[41m B \u001b[42m C \u001b[43m D \u001b[0mText after reset")
-print(u"\u001b[44m E \u001b[45m F \u001b[46m G \u001b[47m H \u001b[0mText after reset")
-print(u"\u001b[40;1m A \u001b[41;1m B \u001b[42;1m C \u001b[43;1m D \u001b[0mText after reset")
-print(u"\u001b[44;1m E \u001b[45;1m F \u001b[46;1m G \u001b[47;1m H \u001b[0mText after reset")
+print("\u001b[40m A \u001b[41m B \u001b[42m C \u001b[43m D \u001b[0mText after reset")
+print("\u001b[44m E \u001b[45m F \u001b[46m G \u001b[47m H \u001b[0mText after reset")
+print("\u001b[40;1m A \u001b[41;1m B \u001b[42;1m C \u001b[43;1m D \u001b[0mText after reset")
+print("\u001b[44;1m E \u001b[45;1m F \u001b[46;1m G \u001b[47;1m H \u001b[0mText after reset")
 
+###############################################################################
 # use text bold, underline, italic or combine them
-print(u"\u001b[1;3;4mText bold, underline and italic \u001b[22mRemove bold only \u001b[23;1mRemove underline and set bold again \u001b[0mReset all")
+print(
+    "\u001b[1;3;4mText bold, underline and italic \u001b[22mRemove bold only "
+    "\u001b[23;1mRemove underline and set bold again \u001b[0mReset all"
+)

--- a/docs/userDoc/source/04_itom_gui/propertyDialog.rst
+++ b/docs/userDoc/source/04_itom_gui/propertyDialog.rst
@@ -121,6 +121,10 @@ General
 
 This tab provides options to decide how text is processed before copying it
 to the clipboard or before pasting it from the clipboard to the command line.
+Furthermore, you can decide if optional ANSI Escape Sequences are identified in
+output or error texts, removed and - if possible - applied as formatting instructions.
+This means, that the text or background color, as well as features like bold, italic
+or underline can be set and reset by these special commands.
 
 Line Wrap
 ---------------------

--- a/docs/userDoc/source/sg_execution_times.rst
+++ b/docs/userDoc/source/sg_execution_times.rst
@@ -6,7 +6,7 @@
 
 Computation times
 =================
-**00:00.143** total execution time for 148 files **from all galleries**:
+**00:00.028** total execution time for 149 files **from all galleries**:
 
 .. container::
 
@@ -32,8 +32,8 @@ Computation times
    * - Example
      - Time
      - Mem (MB)
-   * - :ref:`sphx_glr_11_demos_python_packages_matplotlib_demo_surface3d.py` (``..\..\..\demo\python_packages\matplotlib\demo_surface3d.py``)
-     - 00:00.143
+   * - :ref:`sphx_glr_11_demos_itom_basics_demo_ansiEscapeSequencesOutput.py` (``..\..\..\demo\itom\basics\demo_ansiEscapeSequencesOutput.py``)
+     - 00:00.028
      - 0.0
    * - :ref:`sphx_glr_11_demos_itom_basics_demo_CameraAndImages.py` (``..\..\..\demo\itom\basics\demo_CameraAndImages.py``)
      - 00:00.000
@@ -345,6 +345,9 @@ Computation times
      - 00:00.000
      - 0.0
    * - :ref:`sphx_glr_11_demos_python_packages_matplotlib_demo_streamplot_features.py` (``..\..\..\demo\python_packages\matplotlib\demo_streamplot_features.py``)
+     - 00:00.000
+     - 0.0
+   * - :ref:`sphx_glr_11_demos_python_packages_matplotlib_demo_surface3d.py` (``..\..\..\demo\python_packages\matplotlib\demo_surface3d.py``)
      - 00:00.000
      - 0.0
    * - :ref:`sphx_glr_11_demos_python_packages_matplotlib_demo_tex.py` (``..\..\..\demo\python_packages\matplotlib\demo_tex.py``)

--- a/itomWidgets/itomWidgetsVersion.h
+++ b/itomWidgets/itomWidgetsVersion.h
@@ -1,7 +1,7 @@
 /* ********************************************************************
     itom software
     URL: http://www.uni-stuttgart.de/ito
-    Copyright (C) 2023, Institut fuer Technische Optik (ITO),
+    Copyright (C) 2024, Institut fuer Technische Optik (ITO),
     Universitaet Stuttgart, Germany
 
     This file is part of itom and its software development toolkit (SDK).
@@ -27,9 +27,9 @@
 
 #define ITOM_WIDGETS_VERSION_MAJOR 1
 #define ITOM_WIDGETS_VERSION_MINOR 15
-#define ITOM_WIDGETS_VERSION_PATCH 1
+#define ITOM_WIDGETS_VERSION_PATCH 2
 #define ITOM_WIDGETS_VERSION_REVISION 0
-#define ITOM_WIDGETS_VERSION_STRING "1.15.1.0"
+#define ITOM_WIDGETS_VERSION_STRING "1.15.2.0"
 #define ITOM_WIDGETS_COMPANY        "Institut fuer Technische Optik, University of Stuttgart"
-#define ITOM_WIDGETS_COPYRIGHT      "(C) 2023, ITO, University of Stuttgart"
+#define ITOM_WIDGETS_COPYRIGHT      "(C) 2024, ITO, University of Stuttgart"
 #define ITOM_WIDGETS_NAME           "itomWidgets"

--- a/itomWidgets/pythonLogWidget.cpp
+++ b/itomWidgets/pythonLogWidget.cpp
@@ -61,7 +61,7 @@ public:
         autoScroll(true),
         removeAnsiEscapeSequences(true)
     {
-        m_ansiEscapeSequenceRegExp.setPattern("\\x1B\\[[0-9]{1,2}(;[0-9]{1,3})*m");
+        m_ansiEscapeSequenceRegExp.setPattern("\\x1B\\[([0-9]{1,2}(;[0-9]{1,3})*)?[m,K,J]");
     }
 
     QPlainTextEdit *textEdit;

--- a/itomWidgets/pythonLogWidget.cpp
+++ b/itomWidgets/pythonLogWidget.cpp
@@ -1,7 +1,7 @@
 /* ********************************************************************
     itom software
     URL: http://www.uni-stuttgart.de/ito
-    Copyright (C) 2020, Institut fuer Technische Optik (ITO),
+    Copyright (C) 2024, Institut fuer Technische Optik (ITO),
     University of Stuttgart, Germany
 
     This file is part of itom and its software development toolkit (SDK).
@@ -34,6 +34,7 @@
 #include <qlayout.h>
 #include <qscrollbar.h>
 #include <qmenu.h>
+#include <qregularexpression.h>
 
 #include "common/sharedStructures.h"
 #include "common/apiFunctionsGraphInc.h"
@@ -57,8 +58,10 @@ public:
         outputStream(true),
         errorStream(true),
         sizeHint(300, 120),
-        autoScroll(true)
+        autoScroll(true),
+        removeAnsiEscapeSequences(true)
     {
+        m_ansiEscapeSequenceRegExp.setPattern("\\x1B\\[[0-9]{1,2}(;[0-9]{1,3})*m");
     }
 
     QPlainTextEdit *textEdit;
@@ -68,11 +71,13 @@ public:
     bool errorStream;
     QSize sizeHint;
     bool autoScroll;
+    bool removeAnsiEscapeSequences;
+    QRegularExpression m_ansiEscapeSequenceRegExp;
 };
 
 
 //---------------------------------------------------------------------------------------------------------
-PythonLogWidget::PythonLogWidget(QWidget* parent /*= NULL*/) :
+PythonLogWidget::PythonLogWidget(QWidget* parent /*= nullptr*/) :
     AbstractApiWidget(parent),
     d_ptr(new PythonLogWidgetPrivate(*this))
 {
@@ -138,6 +143,17 @@ void PythonLogWidget::setAutoScroll(bool autoScroll)
 }
 
 //---------------------------------------------------------------------------------------------------------
+void PythonLogWidget::setRemoveAnsiEscapeSequences(bool removeAnsiEscapeSequences)
+{
+    Q_D(PythonLogWidget);
+
+    if (d->removeAnsiEscapeSequences != removeAnsiEscapeSequences)
+    {
+        d->removeAnsiEscapeSequences = removeAnsiEscapeSequences;
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------
 int PythonLogWidget::getMaxMessages() const
 {
     Q_D(const PythonLogWidget);
@@ -172,6 +188,13 @@ bool PythonLogWidget::getAutoScroll() const
 }
 
 //---------------------------------------------------------------------------------------------------------
+bool PythonLogWidget::getRemoveAnsiEscapeSequences() const
+{
+    Q_D(const PythonLogWidget);
+    return d->removeAnsiEscapeSequences;
+}
+
+//---------------------------------------------------------------------------------------------------------
 QSize PythonLogWidget::sizeHint() const
 {
     Q_D(const PythonLogWidget);
@@ -203,7 +226,6 @@ ito::RetVal PythonLogWidget::setOutputStream(bool enabled)
             {
                 retval += apiDisconnectFromOutputAndErrorStream(this, SLOT(messageReceived(QString,ito::tStreamMessageType)), ito::msgStreamOut);
             }
-
         }
         else
         {
@@ -234,7 +256,6 @@ ito::RetVal PythonLogWidget::setErrorStream(bool enabled)
             {
                 retval += apiDisconnectFromOutputAndErrorStream(this, SLOT(messageReceived(QString,ito::tStreamMessageType)), ito::msgStreamErr);
             }
-
         }
         else
         {
@@ -276,6 +297,11 @@ void PythonLogWidget::messageReceived(QString message, ito::tStreamMessageType m
 {
     Q_D(PythonLogWidget);
 
+    if (d->removeAnsiEscapeSequences)
+    {
+        message.remove(d->m_ansiEscapeSequenceRegExp);
+    }
+
     if (d->tempText.size() > 0 && d->tempType != messageType)
     {
         QStringList sl = d->tempText.split("\n");
@@ -289,7 +315,6 @@ void PythonLogWidget::messageReceived(QString message, ito::tStreamMessageType m
         }
         else
         {
-
             foreach (const QString &t, sl)
             {
                 d->textEdit->appendHtml("<font color=\"red\">" + t.toHtmlEscaped().replace(" ", "&nbsp;") + "</font>");
@@ -366,6 +391,4 @@ void PythonLogWidget::showContextMenu(const QPoint &pt)
     menu->exec(d->textEdit->mapToGlobal(pt));
 
     DELETE_AND_SET_NULL(menu);
-
-
 }

--- a/itomWidgets/pythonLogWidget.h
+++ b/itomWidgets/pythonLogWidget.h
@@ -1,7 +1,7 @@
 /* ********************************************************************
     itom software
     URL: http://www.uni-stuttgart.de/ito
-    Copyright (C) 2020, Institut fuer Technische Optik (ITO),
+    Copyright (C) 2024, Institut fuer Technische Optik (ITO),
     University of Stuttgart, Germany
 
     This file is part of itom and its software development toolkit (SDK).
@@ -53,6 +53,7 @@ class ITOMWIDGETS_EXPORT PythonLogWidget : public ito::AbstractApiWidget
     Q_PROPERTY(bool errorStream READ getErrorStream WRITE setErrorStream)
     Q_PROPERTY(int verticalSizeHint READ getVerticalSizeHint WRITE setVerticalSizeHint)
     Q_PROPERTY(bool autoScroll READ getAutoScroll WRITE setAutoScroll)
+    Q_PROPERTY(bool removeAnsiEscapeSequences READ getRemoveAnsiEscapeSequences WRITE setRemoveAnsiEscapeSequences)
 
     WIDGET_ITOM_API
 
@@ -63,6 +64,9 @@ class ITOMWIDGETS_EXPORT PythonLogWidget : public ito::AbstractApiWidget
         void setVerticalSizeHint(int value);
         void clear();
         void setAutoScroll(bool autoScroll);
+        void setRemoveAnsiEscapeSequences(bool removeAnsiEscapeSequences);
+        void messageReceived(QString message, ito::tStreamMessageType messageType);
+        void showContextMenu(const QPoint &pt);
 
 
     Q_SIGNALS:
@@ -77,19 +81,13 @@ class ITOMWIDGETS_EXPORT PythonLogWidget : public ito::AbstractApiWidget
         bool getErrorStream() const;
         int getVerticalSizeHint() const;
         bool getAutoScroll() const;
+        bool getRemoveAnsiEscapeSequences() const;
 
     protected:
-//        void createActions();
         virtual ito::RetVal init();
         QSize sizeHint() const;
 
         QScopedPointer<PythonLogWidgetPrivate> d_ptr;
-
-    public slots:
-        void messageReceived(QString message, ito::tStreamMessageType messageType);
-
-    private Q_SLOTS:
-        void showContextMenu(const QPoint &pt);
 
     private:
         Q_DECLARE_PRIVATE(PythonLogWidget);


### PR DESCRIPTION
The console widget of itom can now handle ANSI escape sequences (see [https://en.wikipedia.org/wiki/ANSI_escape_code](https://en.wikipedia.org/wiki/ANSI_escape_code)), that can be used to format the output or error texts (e.g. text color, background color, bold, underline, italic...). This feature can also be disabled by a setting in the **Console >> General** tab of the itom property editor.

Python packages, like Sphinx or Numba, are using these codes per default. itom can now identify these codes, and if supported, change the style of the affected parts in the texts.

The **pythonLogWidget**, that can be used in user-defined GUIs for displaying Python output or error streams, can not interpret these ANSI escape sequences (or ANSI escape codes), however there is a new property **removeAnsiEscapeSequences**. If true, the special sequence codes are recognized and removed, but not interpreted. Nevertheless, this allows that the text is not messed up with these strange codes.

For examples, sett the demo **itom/basics/demo_ansiEscapeSequencesOutput.py**:
![grafik](https://github.com/itom-project/itom/assets/2607303/11d6ca38-9e70-4f90-bc7a-98f92286e4be)
