### PR TITLE
Handling operatingsystem language setting in additional places.

### DIFF
--- a/AddInManager/addInManagerPrivate.cpp
+++ b/AddInManager/addInManagerPrivate.cpp
@@ -320,9 +320,22 @@ RetVal AddInManagerPrivate::loadAddIn(QString &filename)
         fileInfoDir.cdUp();
         if (language != "en_US" && fileInfoDir.absolutePath() == qApp->applicationDirPath() + "/plugins")
         {
-            QLocale local = QLocale(language); //language can be "language[_territory][.codeset][@modifier]"
+            QLocale localLanguage;
+
+            // language can be "language[_territory][.codeset][@modifier]" or "operatingsystem".
+            // In the last case, the default language of the operating system is used.
+            if (language.compare("operatingsystem", Qt::CaseInsensitive) == 0)
+            {
+                localLanguage = QLocale();
+            }
+            else
+            {
+                localLanguage = QLocale(language);
+            }
+
             QString translationPath = fileInfo.path() + "/translation";
-            QString languageStr = local.name().left(local.name().indexOf("_", 0, Qt::CaseInsensitive));
+            QString languageStr = localLanguage.name().left(
+                localLanguage.name().indexOf("_", 0, Qt::CaseInsensitive));
             QDirIterator it(translationPath, QStringList("*_" + languageStr + ".qm"), QDir::Files);
             if (it.hasNext())
             {

--- a/Qitom/organizer/designerWidgetOrganizer.cpp
+++ b/Qitom/organizer/designerWidgetOrganizer.cpp
@@ -165,9 +165,23 @@ RetVal DesignerWidgetOrganizer::scanDesignerPlugins()
                 fileInfoDir.cdUp();
                 if (language != "en_US" && fileInfoDir.absolutePath() == qApp->applicationDirPath())
                 {
-                    QLocale local = QLocale(language); //language can be "language[_territory][.codeset][@modifier]"
+                    QLocale localLanguage;
+
+                    // language can be "language[_territory][.codeset][@modifier]" or
+                    // "operatingsystem". In the last case, the default language of the operating
+                    // system is used.
+                    if (language.compare("operatingsystem", Qt::CaseInsensitive) == 0)
+                    {
+                        localLanguage = QLocale();
+                    }
+                    else
+                    {
+                        localLanguage = QLocale(language);
+                    }
+
                     QString translationPath = fileInfo.path() + "/translation";
-                    QString languageStr = local.name().left(local.name().indexOf("_", 0, Qt::CaseInsensitive));
+                    QString languageStr = localLanguage.name().left(
+                        localLanguage.name().indexOf("_", 0, Qt::CaseInsensitive));
                     QString baseFileName = fileInfo.baseName();
                     baseFileName.replace("d", "*");
                     QDirIterator it(translationPath, QStringList(baseFileName + "_" + languageStr + ".qm"), QDir::Files);

--- a/Qitom/organizer/uiOrganizer.cpp
+++ b/Qitom/organizer/uiOrganizer.cpp
@@ -685,10 +685,21 @@ QWidget* UiOrganizer::loadUiFile(const QString &filename, RetVal &retValue, QWid
         QString language = settings.value("language", "en").toString();
         settings.endGroup();
 
-        QLocale local = QLocale(language); //language can be "language[_territory][.codeset][@modifier]"
+        QLocale localLanguage;
+
+        // language can be "language[_territory][.codeset][@modifier]" or "operatingsystem".
+        // In the last case, the default language of the operating system is used.
+        if (language.compare("operatingsystem", Qt::CaseInsensitive) == 0)
+        {
+            localLanguage = QLocale();
+        }
+        else
+        {
+            localLanguage = QLocale(language);
+        }
 
         QTranslator *qtrans = new QTranslator();
-        bool couldLoad = qtrans->load(local, fileinfo.baseName(), "_", fileinfo.path());
+        bool couldLoad = qtrans->load(localLanguage, fileinfo.baseName(), "_", fileinfo.path());
         if (couldLoad)
         {
             QString canonicalFilePath = fileinfo.canonicalFilePath();


### PR DESCRIPTION
Until now the new setting to retrieve the language from the operating system was only supported in the main applications. UiItems and AddIns were not translated then. I added the same code as in mainApplication.cpp to the other places where the language is retrieved.

It would probably be better to have a function to retrieve the language but I did not know where this could be implemented to be available for all files and to have access to the settings.

Cheers
Thomas