### PR TITLE
FormatterOnSaveDeadlockFix

### DIFF
--- a/Qitom/organizer/scriptEditorOrganizer.cpp
+++ b/Qitom/organizer/scriptEditorOrganizer.cpp
@@ -516,14 +516,17 @@ RetVal ScriptEditorOrganizer::saveAllScripts(bool askFirst, bool ignoreNewScript
         QStringList unsavedFileNames;
         QMessageBox msgBox;
 
+        // work on a snapshot of m_scriptDockElements, since calls below may indirectly
+        // run a nested event loop (e.g. auto code formatting before save) which can
+        // trigger other slots that try to lock m_scriptStackMutex again -> deadlock.
         m_scriptStackMutex.lock();
+        QList<ScriptDockWidget*> tempList(m_scriptDockElements);
+        m_scriptStackMutex.unlock();
 
-        for (it = m_scriptDockElements.begin(); it != m_scriptDockElements.end(); ++it)
+        for (it = tempList.begin(); it != tempList.end(); ++it)
         {
             unsavedFileNames.append((*it)->getModifiedFilenames(ignoreNewScripts));
         }
-
-        m_scriptStackMutex.unlock();
 
         if (unsavedFileNames.size() > 0)
         {
@@ -570,14 +573,19 @@ RetVal ScriptEditorOrganizer::saveAllScripts(bool askFirst, bool ignoreNewScript
 
     if (saveScriptState == nullptr || *saveScriptState != 2)
     {
+        // work on a snapshot, see comment above. Saving with the auto code formatter
+        // active opens a nested QEventLoop (PyCodeFormatter), during which other
+        // slots that lock m_scriptStackMutex (e.g. getActiveDockWidget) can be
+        // invoked - this would otherwise deadlock and freeze itom, e.g. when
+        // pressing F6 with a modified script in another tab.
         m_scriptStackMutex.lock();
+        QList<ScriptDockWidget*> tempList(m_scriptDockElements);
+        m_scriptStackMutex.unlock();
 
-        for (it = m_scriptDockElements.begin(); it != m_scriptDockElements.end(); ++it)
+        for (it = tempList.begin(); it != tempList.end(); ++it)
         {
             retValue += (*it)->saveAllScripts(false, ignoreNewScripts);
         }
-
-        m_scriptStackMutex.unlock();
     }
 
     return retValue;

--- a/Qitom/widgets/scriptEditorWidget.cpp
+++ b/Qitom/widgets/scriptEditorWidget.cpp
@@ -1752,6 +1752,13 @@ ito::RetVal ScriptEditorWidget::formatPythonCode(int progressDialogShowDelayMs /
         new PyCodeFormatter(progressDialogShowDelayMs, this),
         doDeleteLater);
 
+    // Use a queued connection to make sure the slot is only delivered once the
+    // local QEventLoop below is actually running. Otherwise, if the formatter
+    // process fails to start (e.g. wrong python path / insufficient rights) or
+    // finishes extremely fast, formattingDone is emitted synchronously from
+    // within startSortingAndFormatting(...) and loop.exit() would be called
+    // before loop.exec(). The following loop.exec() would then block forever
+    // and freeze itom (e.g. when running a modified script with format-on-save).
     connect(
         pyCodeFormatter.data(),
         &PyCodeFormatter::formattingDone,
@@ -1759,7 +1766,8 @@ ito::RetVal ScriptEditorWidget::formatPythonCode(int progressDialogShowDelayMs /
         [&](bool success, QString codeOrErrorString)
         {
             pyCodeFormatterDone(success, codeOrErrorString, loop);
-        }
+        },
+        Qt::QueuedConnection
     );
 
 


### PR DESCRIPTION
Fix deadlock and freeze issues during script saving and formatting by using snapshots of script dock elements and queued connections for event loops.